### PR TITLE
Add heroku open addon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Installation in Heroku
 
 ### Set cron job for to automatically back-up your slack history
 
+Open the scheduler
+
+    heroku addons:open scheduler
+
 [https://scheduler.heroku.com/dashboard](https://scheduler.heroku.com/dashboard)
 
 Add follow in command into your heroku schedule, set frequency to "Every 10 minutes"


### PR DESCRIPTION
When I accessed the scheduler dashboard without running the addons:open command I just saw a blank page.